### PR TITLE
chore: simplify, modernize (Go 1.26), update deps

### DIFF
--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ func (c *Config) Valid() error {
 		return errors.E(op, errors.Str("empty address"))
 	}
 
-	if c.Configuration == nil {
+	if len(c.Configuration) == 0 {
 		return errors.E(op, errors.Str("no configuration to serve"))
 	}
 

--- a/config.go
+++ b/config.go
@@ -41,21 +41,21 @@ func (c *Config) Valid() error {
 		return errors.E(op, errors.Str("no configuration to serve"))
 	}
 
-	for i := range c.Configuration {
-		if c.Configuration[i].Prefix == "" {
+	for _, cfg := range c.Configuration {
+		if cfg.Prefix == "" {
 			return errors.E(op, errors.Str("empty prefix"))
 		}
 
-		if c.Configuration[i].Prefix[0] != '/' {
+		if cfg.Prefix[0] != '/' {
 			return errors.E(op, errors.Str("prefix must begin with a forward slash"))
 		}
 
-		if c.Configuration[i].Root == "" {
-			c.Configuration[i].Root = "."
+		if cfg.Root == "" {
+			cfg.Root = "."
 		}
 
-		if c.Configuration[i].CacheDuration == 0 {
-			c.Configuration[i].CacheDuration = 10
+		if cfg.CacheDuration == 0 {
+			cfg.CacheDuration = 10
 		}
 	}
 

--- a/plugin.go
+++ b/plugin.go
@@ -45,6 +45,10 @@ func (p *Plugin) Init(cfg Configurer, log Logger) error {
 		return errors.E(op, err)
 	}
 
+	if err = p.config.Valid(); err != nil {
+		return errors.E(op, err)
+	}
+
 	p.log = log.NamedLogger(pluginName)
 
 	return nil
@@ -55,20 +59,13 @@ func (p *Plugin) Serve() chan error {
 
 	p.Lock()
 	p.app = fiber.New(fiber.Config{
-		ReadBufferSize:               1 * 1024 * 1024,
-		WriteBufferSize:              1 * 1024 * 1024,
-		Prefork:                      false,
-		BodyLimit:                    10 * 1024 * 1024,
-		ReadTimeout:                  time.Second * 10,
-		WriteTimeout:                 time.Second * 10,
-		DisableKeepalive:             false,
-		DisableDefaultDate:           false,
-		DisableDefaultContentType:    false,
-		DisableHeaderNormalizing:     false,
-		DisableStartupMessage:        true,
-		StreamRequestBody:            p.config.StreamRequestBody,
-		DisablePreParseMultipartForm: false,
-		ReduceMemoryUsage:            false,
+		ReadBufferSize:        1 * 1024 * 1024,
+		WriteBufferSize:       1 * 1024 * 1024,
+		BodyLimit:             10 * 1024 * 1024,
+		ReadTimeout:           time.Second * 10,
+		WriteTimeout:          time.Second * 10,
+		DisableStartupMessage: true,
+		StreamRequestBody:     p.config.StreamRequestBody,
 	})
 
 	if p.config.CalculateEtag {
@@ -77,18 +74,19 @@ func (p *Plugin) Serve() chan error {
 		}))
 	}
 
-	for i := range p.config.Configuration {
-		p.app.Static(p.config.Configuration[i].Prefix, p.config.Configuration[i].Root, fiber.Static{
-			Compress:      p.config.Configuration[i].Compress,
-			ByteRange:     p.config.Configuration[i].BytesRange,
+	for _, cfg := range p.config.Configuration {
+		p.app.Static(cfg.Prefix, cfg.Root, fiber.Static{
+			Compress:      cfg.Compress,
+			ByteRange:     cfg.BytesRange,
 			Browse:        false,
-			CacheDuration: time.Second * time.Duration(p.config.Configuration[i].CacheDuration),
-			MaxAge:        p.config.Configuration[i].MaxAge,
+			CacheDuration: time.Second * time.Duration(cfg.CacheDuration),
+			MaxAge:        cfg.MaxAge,
 		})
 	}
 
 	ln, err := tcplisten.CreateListener(p.config.Address)
 	if err != nil {
+		p.Unlock()
 		errCh <- err
 		return errCh
 	}
@@ -96,10 +94,8 @@ func (p *Plugin) Serve() chan error {
 	go func() {
 		p.Unlock()
 		p.log.Info("file server started", "address", p.config.Address)
-		err = p.app.Listener(ln)
-		if err != nil {
+		if err := p.app.Listener(ln); err != nil {
 			errCh <- err
-			return
 		}
 	}()
 
@@ -107,29 +103,19 @@ func (p *Plugin) Serve() chan error {
 }
 
 func (p *Plugin) Stop(ctx context.Context) error {
-	endCh := make(chan struct{}, 1)
-	errCh := make(chan error, 1)
+	doneCh := make(chan error, 1)
 
 	go func() {
 		p.Lock()
 		defer p.Unlock()
-
-		err := p.app.Shutdown()
-		if err != nil {
-			errCh <- err
-			return
-		}
-
-		endCh <- struct{}{}
+		doneCh <- p.app.ShutdownWithContext(ctx)
 	}()
 
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case e := <-errCh:
-		return e
-	case <-endCh:
-		return nil
+	case err := <-doneCh:
+		return err
 	}
 }
 


### PR DESCRIPTION
## Applied fixes

**Bug fixes (R)**
- `plugin.go:90` — Mutex was left locked when `CreateListener` fails; `Stop` would deadlock. Fixed by calling `p.Unlock()` on the error path before returning.
- `plugin.go:117` — `Stop` called `app.Shutdown()` which ignores the passed `ctx` deadline. Replaced with `app.ShutdownWithContext(ctx)`.
- `plugin.go:36` — `Config.Valid()` was defined but never called in `Init`; invalid config (empty address, missing serve entries) would silently produce a broken server. Now called after `UnmarshalKey`.
- `plugin.go:99` — `err = p.app.Listener(ln)` reused the outer `err` via closure; replaced with `:=` scoped to the goroutine.

**Simplify (S)**
- `plugin.go:57` — Removed 7 explicit zero-value fields from `fiber.Config` (noise).
- `plugin.go:80` — Index range over `[]*Cfg` replaced with range-over-value.
- `plugin.go:110` — Merged `endCh` + `errCh` into a single `chan error` in `Stop`.
- `config.go:44` — Index range over `[]*Cfg` replaced with range-over-value.

**Modern Go (M)**
- `plugin.go:80`, `config.go:44` — Go 1.22 range-over-element (same as S items above).

## Deps
`go get -u all && go mod tidy` — all dependencies were already at latest; no version changes in go.mod.

